### PR TITLE
fix __FILE__ macro

### DIFF
--- a/src/parser/preprocessor/default.cpp
+++ b/src/parser/preprocessor/default.cpp
@@ -1067,7 +1067,7 @@ std::string file_macro_callback(
     const std::vector<std::string>& params,
     ::sqf::runtime::runtime& runtime)
 {
-    return dinf.path.physical;
+    return "\""s + dinf.path.physical + "\""s;
 }
 std::string eval_macro_callback(
     const ::sqf::runtime::parser::macro& m,


### PR DESCRIPTION
`__FILE__` should be quote wrapped

```
.\sqfvm.exe --input "F:\DEV\CBA_A3\addons\hashes\fnc_hashEachPair.sqf" -v "F:\DEV\CBA_A3|\x\cba" --parse-only --automated
[ERR] [L46|C250|F:\DEV\CBA_A3\addons\hashes\fnc_hashEachPair.sqf]       Parse Error: syntax error, unexpected INVALID
```
```
#define DEBUG_MODE_FULL
#include "script_component.hpp"
TRACE_2("test",_a,_b);
```
becomes
```
    format ['[%1] (%2) %3: %4', toUpper 'cba', 'hashes', 'TRACE', format ['%1 %2:%3', format ['%1: _key=%2, _value=%3', str diag_frameNo + ' ' + ("VM CHECK"), (if (isNil {_key}) then [{nil}, {_key}]), (if (isNil {_value}) then [{nil}, {_value}])], F:\DEV\CBA_A3\addons\hashes\fnc_hashEachPair.sqf, 46 + 1]] call CBA_fnc_log;
```