### PR TITLE
ops_config - Fix >> with null left. Work on configClasses

### DIFF
--- a/src/operators/ops_config.cpp
+++ b/src/operators/ops_config.cpp
@@ -24,7 +24,7 @@ namespace
         auto cd = left.data<d_config, config>();
         if (cd.is_null())
         {
-            runtime.__logmsg(err::ExpectedNonNullValue(runtime.context_active().current_frame().diag_info_from_position()));
+            runtime.__logmsg(err::ExpectedNonNullValueWeak(runtime.context_active().current_frame().diag_info_from_position()));
             runtime.__logmsg(err::ReturningConfigNull(runtime.context_active().current_frame().diag_info_from_position()));
             return config();
         }
@@ -250,10 +250,11 @@ namespace
                 auto res = runtime.context_active().pop_value();
                 if (res.has_value())
                 {
-                    auto value = res->data_try<d_boolean, bool>();
-                    if (value.has_value())
+                    if (res->is<t_boolean>())
                     {
-                        m_out_arr->push_back({ *m_iterator_current });
+                        if (res->data<d_boolean, bool>()) {
+                            m_out_arr->push_back({ *m_iterator_current });
+                        }
                     }
                     else
                     {
@@ -301,7 +302,7 @@ namespace
             if (res.has_value())
             {
                 frame f(runtime.default_value_scope(), res.value(), std::make_shared<behavior_configclasses_exit>(nav));
-                f["_x"] = nav->operator[](0);
+                f["_x"] = { *(nav.begin()) };
                 runtime.context_active().push_frame(f);
             }
         }

--- a/src/runtime/confighost.h
+++ b/src/runtime/confighost.h
@@ -152,7 +152,7 @@ namespace sqf::runtime
                 while (m_id != config::invalid_id)
                 {
                     auto& container = m_confighost.m_containers[m_id];
-                    if (container.size() != m_index)
+                    if ((container.size() - 1) > m_index)
                     {
                         m_index++;
                         return *this;
@@ -173,7 +173,7 @@ namespace sqf::runtime
                 return *this;
             }
             iterator_base<recursive> operator++(int) { iterator retval = *this; ++(*this); return retval; }
-            bool operator==(iterator_base<recursive> other) const { return m_index == other.m_id; }
+            bool operator==(iterator_base<recursive> other) const { return m_id == other.m_id; }
             bool operator!=(iterator_base<recursive> other) const { return !(*this == other); }
             value_type operator*()
             {

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -27,3 +27,10 @@ class type_tests
     type_scalar = 1;
     class type_class {};
 };
+class flat_tests {
+    class A { key = 1; };
+    class B { key = 2; };
+    class C: A {};
+    class D: C { key = 4; };
+    class E: B { key = 5; };
+};

--- a/tests/sqf/! config.sqf
+++ b/tests/sqf/! config.sqf
@@ -45,5 +45,13 @@
     ["assertEqual",     { getNumber (configFile >> "doesNotExist") }, 0],
     ["assertEqual",     { getText configNull }, ""],
     ["assertEqual",     { getText (configFile >> "doesNotExist") }, ""],
-    ["assertTrue",      { isNull configNull }]
+    ["assertTrue",      { isNull configNull }],
+    ["assertTrue",      { isNull (configFile >> "doesNotExist" >> "anything") }],
+    ["assertTrue",      { !isClass (configFile >> "doesNotExist" >> "anything") }],
+    ["assertTrue",      { isNull (configFile / "doesNotExist" / "anything") }],
+    ["assertTrue",      { !isClass (configFile / "doesNotExist" / "anything") }],
+    ["assertEqual",     { count ("true" configClasses (configFile >> "flat_tests")) }, 5],
+    ["assertEqual",     { ("getNumber (_x >> 'key') == 2" configClasses (configFile >> "flat_tests")) }, [configFile >> "flat_tests" >> "B"]],
+    ["assertEqual",     { ("getNumber (_x >> 'key') == 5" configClasses (configFile >> "flat_tests")) }, [configFile >> "flat_tests" >> "E"]],
+    ["assertEqual",     { ("(getNumber (_x >> 'key')) % 2 == 0" configClasses (configFile >> "flat_tests")) }, [configFile >> "flat_tests" >> "B", configFile >> "flat_tests" >> "D"]]
 ]


### PR DESCRIPTION
- Fix `configFile >> "doesNotExist" >> "anything"` causing fatal error
- Attempt to get `configClasses` working