### PR TITLE
Use static libstd++/libgcc linking to avoid compatibility issues

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -20,6 +20,9 @@ jobs:
           CC: clang
           CXX: clang++
 
+      - name: Sanity check
+        run: build/sqfvm --version
+
       - name: Move binary to docker directory
         run: mv build/sqfvm docker/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (MSVC)
   add_definitions(/MP /W4 /wd4100)
 else()
   add_definitions(-Wall -Wno-unknown-pragmas)
+  add_link_options(-static-libstdc++ -static-libgcc)
 endif()
 
 # Add the filesystem library if we are building on Clang or GCC


### PR DESCRIPTION
Currently, `sqfvm` build on GitHub Ubuntu 18.04 cannot run on clean Ubuntu 18.04, because the right libstd++ is missing by default