### PR TITLE
Fixed ctest to correctly execute SQF using existing framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run SQF-VM Tests
         working-directory: build
-        run: ctest
+        run: ctest --output-on-failure
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -48,7 +48,7 @@ jobs:
 
       - name: Run SQF-VM Tests
         working-directory: build
-        run: ctest
+        run: ctest --output-on-failure
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run SQF-VM Tests
         working-directory: build
-        run: ctest
+        run: ctest --output-on-failure
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run SQF-VM Tests
         working-directory: build
-        run: ctest -C Release
+        run: ctest --output-on-failure -C Release
 
       - name: Run CBA A3 Tests
         run: |
@@ -116,7 +116,7 @@ jobs:
 
       - name: Run SQF-VM Tests
         working-directory: build
-        run: ctest -C Release
+        run: ctest --output-on-failure -C Release
 
       - name: Run CBA A3 Tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
           path: build/sqfvm*
 
       - name: Run SQF-VM Tests
-        run: cd build && ctest
+        working-directory: build
+        run: ctest
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -46,7 +47,8 @@ jobs:
           path: build/sqfvm*
 
       - name: Run SQF-VM Tests
-        run: cd build && ctest
+        working-directory: build
+        run: ctest
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -67,7 +69,8 @@ jobs:
           path: build/sqfvm*
 
       - name: Run SQF-VM Tests
-        run: cd build && ctest
+        working-directory: build
+        run: ctest
 
       - name: Run CBA A3 Tests
         run: PATH=build:$PATH python tests/cba/cba_a3.py
@@ -88,7 +91,8 @@ jobs:
           path: build/Release/*.exe
 
       - name: Run SQF-VM Tests
-        run: cd build && ctest -C Release
+        working-directory: build
+        run: ctest -C Release
 
       - name: Run CBA A3 Tests
         run: |
@@ -111,7 +115,8 @@ jobs:
           path: build/Release/*.exe
 
       - name: Run SQF-VM Tests
-        run: cd build && ctest -C Release
+        working-directory: build
+        run: ctest -C Release
 
       - name: Run CBA A3 Tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,5 @@ build/git_sha1\.cpp
 
 *.diagsession
 src/sqc/parser.output
+/tests/_out1_.txt
+/tests/_err1_.txt

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -46,11 +46,11 @@ void cli::handle_files()
             auto [path, contents] = generator();
             if (key == "sqf")
             {
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, contents, { path.string(), {} });
                 if (ppedStr.has_value())
                 {
-                    if (verbose()) { std::cout << "Parsing file '" << path << std::endl; }
+                    if (verbose()) { std::cout << "Parsing file '" << path << "'" << std::endl; }
                     if (m_parse_only)
                     {
                         auto success = m_runtime.parser_sqf().check_syntax(m_runtime, *ppedStr, { path.string(), {} });
@@ -82,11 +82,11 @@ void cli::handle_files()
             }
             else if (key == "config")
             {
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, contents, { path.string(), {} });
                 if (ppedStr.has_value())
                 {
-                    if (verbose()) { std::cout << "Parsing file '" << path << std::endl; }
+                    if (verbose()) { std::cout << "Parsing file '" << path << "'" << std::endl; }
                     if (m_parse_only)
                     {
                         auto success = !m_runtime.parser_config().check_syntax(*ppedStr, { path.string(), {} });
@@ -112,11 +112,11 @@ void cli::handle_files()
             else if (key == "sqc")
             {
                 sqf::sqc::parser sqc_parser(m_logger);
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, contents, { path.string(), {} });
                 if (ppedStr.has_value())
                 {
-                    if (verbose()) { std::cout << "Parsing file '" << path << std::endl; }
+                    if (verbose()) { std::cout << "Parsing file '" << path << "'" << std::endl; }
                     if (m_parse_only)
                     {
                         auto success = sqc_parser.check_syntax(m_runtime, *ppedStr, { path.string(), {} });
@@ -148,11 +148,11 @@ void cli::handle_files()
             }
             else if (key == "sqf2sqc")
             {
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, contents, { path.string(), {} });
                 if (ppedStr.has_value())
                 {
-                    if (verbose()) { std::cout << "Parsing file '" << path << std::endl; }
+                    if (verbose()) { std::cout << "Parsing file '" << path << "'" << std::endl; }
                     if (m_parse_only)
                     {
                         auto success = m_runtime.parser_sqf().check_syntax(m_runtime, *ppedStr, { path.string(), {} });
@@ -193,11 +193,11 @@ void cli::handle_files()
             else if (key == "sqc2sqf")
             {
                 sqf::sqc::parser sqc_parser(m_logger);
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, contents, { path.string(), {} });
                 if (ppedStr.has_value())
                 {
-                    if (verbose()) { std::cout << "Parsing file '" << path << std::endl; }
+                    if (verbose()) { std::cout << "Parsing file '" << path << "'" << std::endl; }
                     if (m_parse_only)
                     {
                         auto success = sqc_parser.check_syntax(m_runtime, *ppedStr, { path.string(), {} });
@@ -412,7 +412,7 @@ int cli::run(size_t argc, const char** argv)
 
     // Preprocessing
     CMDADD(TCLAP::MultiArg<std::string>,    preprocessFileArg,          "E",    "preprocess-file",          "Runs the preprocessor on provided file and prints it to stdout. " RELPATHHINT "!BE AWARE! This is case-sensitive!", false, "PATH");
-    CMDADD(TCLAP::MultiArg<std::string>,    defineArg,                  "D",    "define",                   "Allows to add PreProcessor definitions. Note that file-based definitions may override and/or conflict with theese.", false, "NAME|NAME=VALUE");
+    CMDADD(TCLAP::MultiArg<std::string>,    defineArg,                  "D",    "define",                   "Allows to add PreProcessor definitions. Note that file-based definitions may override and/or conflict with these.", false, "NAME|NAME=VALUE");
 
     // Dummy Operators
     CMDADD(TCLAP::MultiArg<std::string>,    commandDummyNular,          "",     "command-dummy-nular",      "Adds the provided command as dummy.", false, "NAME");
@@ -679,7 +679,7 @@ int cli::run(size_t argc, const char** argv)
                     continue;
                 }
                 auto str = *file;
-                if (verbose()) { std::cout << "Preprocessing file '" << path << std::endl; }
+                if (verbose()) { std::cout << "Preprocessing file '" << path << "'" << std::endl; }
                 auto ppedStr = m_runtime.parser_preprocessor().preprocess(m_runtime, str, { path.string(), {} });
                 if (ppedStr.has_value())
                 {

--- a/src/sqc/ReadMe.md
+++ b/src/sqc/ReadMe.md
@@ -70,7 +70,7 @@ Instead, SQC attempts to automatically mangle the different types and functions 
 
 For example, a call to `diag_log` in SQC, treats `diag_log` as method which makes the call look like this: `diag_log("fooo bar")`.
 special attention should be given to operators, expecting arrays as their parameter though.
-For theese, SQC automatically transforms parameter lists into arrays (`nearestObjects(player, ["Tank"],500)`) however, given that only one argument
+For these, SQC automatically transforms parameter lists into arrays (`nearestObjects(player, ["Tank"],500)`) however, given that only one argument
 gets passed to an operator expecting an array, the correct way to call that then is to pass the array then as a proper array (`private(["_someVar"])`)
 
 With Binary operators (eg. `in`), SQC gives you a somewhat OOP way to access them, making `player setPosition [1,2,3]` to `player.setPosition(1,2,3)`.
@@ -139,7 +139,7 @@ In SQC, a function is made using the following syntax:
 ```
 ### Function Args
 `<ARGS>` are a comma separated list of "arguments" that the method shall receive.
-Theese can be typed. They follow the following syntax:
+these can be typed. They follow the following syntax:
 
 ```js
     variableName
@@ -157,7 +157,7 @@ existing variables in the function code. This is what that syntax does. It rewri
 
 Full example: `arr.select(function(it: "_x") { return it > 2; });` gets `arr select { _x > 2 }`
 ## File Header
-SQC Files may start with a so called "params" directive. This is so, that CfgFunctions may be used to initialize theese methods.
+SQC Files may start with a so called "params" directive. This is so, that CfgFunctions may be used to initialize these methods.
 It lends itself the comma separated list of `<ARGS>` known from Functions and looks like this:
 
 ```js

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,9 @@ function(add_sqf_run_test test_full_path)
 	message(VERBOSE "Registering test " ${test_full_path} " as " ${test_full_name})
 	add_test(
 		NAME "${test_full_name}"
-		COMMAND sqfvm -a -V --no-execute-print --input-sqf "framework.sqf" --input-config ${TEST_ROOT_LOCATION}/config.cpp --sqf "\"\\\"${test_relative_path}\\\" call test_fnc_run_from_file;\"" --max-runtime 10000
+		COMMAND sqfvm -a -V --no-execute-print --max-runtime 1000
+                --input-sqf "framework.sqf" --input-config ${TEST_ROOT_LOCATION}/config.cpp 
+                --sqf "\"${test_relative_path}\" call test_fnc_run_from_file;"
 		WORKING_DIRECTORY ${TEST_ROOT_LOCATION}
 	)
 	set_tests_properties(${test_full_name} PROPERTIES TIMEOUT 11)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,17 @@
 # Register all .sqf tests
 
-set(TEST_CONFIG_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/config.cpp)
+set(TEST_ROOT_LOCATION ${CMAKE_CURRENT_SOURCE_DIR})
 
 function(add_sqf_run_test test_full_path)
 	get_filename_component(test_name ${test_full_path} NAME_WE)
+    file(RELATIVE_PATH test_relative_path ${TEST_ROOT_LOCATION} ${test_full_path})
 	set(test_full_name run.${test_name})
 
-	message("Registering test " ${test_full_path} " as " ${test_full_name})
+	message(VERBOSE "Registering test " ${test_full_path} " as " ${test_full_name})
 	add_test(
 		NAME "${test_full_name}"
-		COMMAND sqfvm -a -V --no-execute-print --input-sqf ${test_full_path} --input-config ${TEST_CONFIG_LOCATION} --max-runtime 10000
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		COMMAND sqfvm -a -V --no-execute-print --input-sqf "framework.sqf" --input-config ${TEST_ROOT_LOCATION}/config.cpp --sqf "\"\\\"${test_relative_path}\\\" call test_fnc_run_from_file;\"" --max-runtime 10000
+		WORKING_DIRECTORY ${TEST_ROOT_LOCATION}
 	)
 	set_tests_properties(${test_full_name} PROPERTIES TIMEOUT 11)
 endfunction()
@@ -19,11 +20,11 @@ function(add_sqf_preprocess_test test_full_path)
 	get_filename_component(test_name ${test_full_path} NAME_WE)
 	set(test_full_name preprocess.${test_name})
 
-	message("Registering test " ${test_full_path} " as " ${test_full_name})
+	message(VERBOSE "Registering test " ${test_full_path} " as " ${test_full_name})
 	add_test(
 		NAME "${test_full_name}"
-		COMMAND sqfvm -a -V --no-execute-print --preprocess-file ${test_full_path} --input-config ${TEST_CONFIG_LOCATION} --max-runtime 10000
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+		COMMAND sqfvm -a -V --no-execute-print --preprocess-file ${test_full_path} --input-config ${TEST_ROOT_LOCATION}/config.cpp --max-runtime 10000
+		WORKING_DIRECTORY ${TEST_ROOT_LOCATION}
 	)
 endfunction()
 

--- a/tests/ReadMe.md
+++ b/tests/ReadMe.md
@@ -5,11 +5,11 @@ The test-framework depends heavily on SQF-VM own commands and can be used as a r
 implementation (or straight copied) for your own Test-Framework using SQF-VM.
 
 Due to features like `assertException` expecting runtime-errors and Arma not being able to handle
-theese, this test-framework can be deemed as incompatible to Arma.
+these, this test-framework can be deemed as incompatible to Arma.
 
 ## Executing Tests ##
 
-To run theese tests, start SQF-VM with the following commands:
+To run these tests, start SQF-VM with the following commands:
 
 `-a -i tests/config.cpp -i tests/runTests.sqf`
 

--- a/tests/cba/CMakeLists.txt
+++ b/tests/cba/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_sqf_run_test(${CMAKE_CURRENT_SOURCE_DIR}/cba_a3.sqf)
+# add_sqf_run_test(${CMAKE_CURRENT_SOURCE_DIR}/cba_a3.sqf)

--- a/tests/framework.sqf
+++ b/tests/framework.sqf
@@ -1,0 +1,274 @@
+/*********************************************************
+ * The following SQF code REQUIRES SQF-VM                *
+ * to work. There are special, SQF-VM only commands      *
+ * used, to make it as productive as possible.           *
+ *                                                       *
+ * SQF-VM commands are suffixed with a double underscore *
+ * (eg. exitcode__)                                      *
+ ********************************************************/
+
+
+// #define _TEST_FRAMEWORK_DEBUG
+
+
+#ifdef _TEST_FRAMEWORK_DEBUG
+#define DIAGNOSTICS(MESSAGE) diag_log #MESSAGE
+#define DIAGNOSTICS_EXEC(MESSAGE) diag_log (MESSAGE)
+#else
+#define DIAGNOSTICS(MESSAGE)
+#define DIAGNOSTICS_EXEC(MESSAGE)
+#endif
+#define COMMA ,
+
+diag_log str productVersion;
+diag_log format(["%1"] + productVersion);
+diag_log format(["v %3.%4 (%5)"] + productVersion);
+diag_log format(["%7 %8"] + productVersion);
+
+testsIndex = 0;
+testsPassed = 0;
+testsFailed = 0;
+fatalError = false;
+
+test_fnc_testPassed = {
+    params["___name___", "___desc___", "___index___"];
+    DIAGNOSTICS(TEST PASSED);
+    diag_log format["Test  Passed  '%1' - %2", ___name___, ___index___ + 1];
+    testsPassed = testsPassed + 1;
+};
+
+test_fnc_testFailed = {
+    params["___name___", "___desc___", "___index___", "___msg___"];
+    DIAGNOSTICS(TEST FAILED);
+    private _msg1 = format["Test !FAILED! '%1' - %2  %3", ___name___, ___index___ + 1, trim__ ___desc___];
+    diag_log _msg1;
+    diag_log ___msg___;
+    ___failed___ pushBack _msg1;
+    testsFailed = testsFailed + 1;
+};
+
+test_fnc_assertEqual = {
+    [_this, {
+        params["___name___", "___test___", "___desc___", "___index___", "___compare___"];
+        private ___ret___ = call ___test___;
+        DIAGNOSTICS_EXEC(format ["___ret___: %1" COMMA ___ret___]);
+        DIAGNOSTICS_EXEC(format ["___compare___: %1" COMMA ___compare___]);
+        if (___ret___ isEqualTo ___compare___) then
+        {
+            [___name___, ___desc___, ___index___] call test_fnc_testPassed;
+        }
+        else
+        {
+            private ___msg___ = format[
+                "Wrong return value. Expected %1 (type %2), got %3 (type %4).",
+                ___compare___,
+                typeName ___compare___,
+                ___ret___,
+                typeName ___ret___
+            ];
+            [___name___, ___desc___, ___index___, ___msg___] call test_fnc_testFailed;
+        }
+    }] call test_fnc_exceptWrapper;
+};
+
+test_fnc_assert = {
+    [_this, {
+        params["___name___", "___test___", "___desc___", "___index___", "___compare___"];
+        private ___ret___ = call ___test___;
+        [___name___, ___desc___, ___index___] call test_fnc_testPassed;
+    }] call test_fnc_exceptWrapper;
+};
+
+test_fnc_assertIsNil = {
+    [_this, {
+        params["___name___", "___test___", "___desc___", "___index___", "___compare___"];
+        private ___ret___ = call ___test___;
+        if (isNil "___ret___") then
+        {
+            [___name___, ___desc___, ___index___] call test_fnc_testPassed;
+        }
+        else
+        {
+            private ___msg___ = format["Wrong return value. Expected nil, got %1 (type %2).",  ___ret___, typeName ___ret___];
+            [___name___, ___desc___, ___index___, ___msg___] call test_fnc_testFailed;
+        }
+    }] call test_fnc_exceptWrapper;
+};
+
+test_fnc_assertException = {
+    [_this, {
+        params["___name___", "___test___", "___desc___", "___index___"];
+        {
+            private ___ret___ = call ___test___;
+            private ___msg___ = format["Never reached except. Returned: %1", ___ret___];
+            [___name___, ___desc___, ___index___, ___msg___] call test_fnc_testFailed;
+        }
+        except__
+        {
+            [___name___, ___desc___, ___index___] call test_fnc_testPassed;
+        }
+    }] call test_fnc_exceptWrapper;
+};
+
+test_fnc_exceptWrapper = {
+    params["___exceptWrapper_args___", "___exceptWrapper_code___"];
+    {
+        ___exceptWrapper_args___ call ___exceptWrapper_code___
+    }
+    except__
+    {
+        private ___msg___ = format["Exception occurred: %1",  _exception];
+        [___exceptWrapper_args___ select 0, ___exceptWrapper_args___ select 2, ___exceptWrapper_args___ select 3, ___msg___] call test_fnc_testFailed;
+    }
+};
+test_fnc_setupWrapper = {
+    params["___setupWrapper_args___", "___setupWrapper_code___"];
+    {
+        ___setupWrapper_args___ call ___setupWrapper_code___
+    }
+    except__
+    {
+        private ___msg___ = format["Exception occurred during setup: %1",  _exception];
+        fatalError = true;
+    }
+};
+test_fnc_cleanup_carraige_return = {
+    params["___text___"];
+    toString (toArray ___text___ select { /* take all chars but carraige return '\r' */ _x != 13 });
+};
+
+test_fnc_run_from_file = {
+    private ___exceptions___ = [];
+    private ___failed___ = [];
+    private ___file___ = _this;
+
+    diag_log format["Loading tests from"];
+    diag_log format["    %1", ___file___];
+
+    DIAGNOSTICS_EXEC(format["Going to execute file: %1", ___file___]);
+    DIAGNOSTICS_EXEC(format["%1 out of %2 tests passed." COMMA testsPassed COMMA testsIndex]);
+
+    {
+        private ___tests___ = call compile preprocessFileLineNumbers ___file___;
+        private ___name___ = ___file___; // TODO
+        if (isNil "___tests___") then 
+        {
+            exitcode__(999999);
+        };
+        private ___setup___ = { [] call _this; };
+        if !(___tests___ isEqualType []) then
+        {
+            throw format["Invalid type. Expected ARRAY; Got %1", typeName ___tests___];
+            fatalError = true;
+        };
+        {
+            DIAGNOSTICS_EXEC(format["%1 out of %2 tests passed." COMMA testsPassed COMMA testsIndex]);
+            testsIndex = testsIndex + 1;
+            private ___mode___ = _x select 0;
+            private ___test___ = _x select 1;
+            private ___desc___ = if (___test___ isEqualType[]) then { ___test___ select 0 } else { str(___test___) };
+            private ___code___ = if (___test___ isEqualType[]) then { ___test___ select 1 } else { ___test___ };
+                
+            private ___res___ = false;
+            if (___mode___ isEqualType "") then
+            {
+                switch (___mode___) do
+                {
+                    case "setup": {
+                        DIAGNOSTICS_EXEC("___mode___ is setup");
+                        ___setup___ = ___code___;
+                        testsIndex = testsIndex - 1;
+                    };
+                    case "assert": {
+                        DIAGNOSTICS_EXEC("___mode___ is assert");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex, true] call test_fnc_assert
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    case "assertTrue": {
+                        DIAGNOSTICS_EXEC("___mode___ is assertTrue");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex, true] call test_fnc_assertEqual
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    case "assertFalse": {
+                        DIAGNOSTICS_EXEC("___mode___ is assertFalse");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex, false] call test_fnc_assertEqual
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    case "assertEqual": {
+                        DIAGNOSTICS_EXEC("___mode___ is assertEqual");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex, _x select 2] call test_fnc_assertEqual
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    case "assertNil";
+                    case "assertIsNil": {
+                        DIAGNOSTICS_EXEC("___mode___ is assertNil");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex] call test_fnc_assertIsNil
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    case "assertExcept";
+                    case "assertException": {
+                        DIAGNOSTICS_EXEC("___mode___ is assertException");
+                        [{
+                            [___name___, ___code___, ___desc___, _forEachIndex] call test_fnc_assertException
+                        }, ___setup___] call test_fnc_setupWrapper;
+                    };
+                    default {
+                        throw format["Unknown Test-Type %1 in %2-%3 (%4)", ___mode___, ___name___, _forEachIndex + 1, ___desc___];
+                        fatalError = true;
+                    }
+                }
+            }
+            else
+            {
+                if (___mode___ isEqualType {}) then
+                {
+                    DIAGNOSTICS_EXEC("___mode___ is CODE");
+                    ___res___ = [___name___, ___test___, _forEachIndex, _x] call ___mode___;
+                }
+                else
+                {
+                    throw format["Test-Type was expected to be either STRING or CODE but was %1", typeName ___mode___];
+                    fatalError = true;
+                };
+            };
+        } forEach ___tests___;
+    }
+    except__
+    {
+        private _msg = format["Exception during test execution of %1: %2%3", _x, endl, _exception];
+        diag_log _msg;
+        ___exceptions___ pushBack _msg;
+        fatalError = true;
+    };
+    diag_log "############################################################";
+    diag_log format["%1 out of %2 tests passed.", testsPassed, testsIndex];
+    diag_log "############################################################";
+    {
+        diag_log _x;
+    } forEach ___failed___;
+    if (testsPassed != testsIndex) then
+    {
+        diag_log "############################################################";
+        diag_log format["%1 out of %2 tests passed.", testsPassed, testsIndex];
+        diag_log "############################################################";
+    };
+    if (fatalError) then
+    {
+        diag_log "FATALERROR occured during testing:";
+        {
+            diag_log _x;
+        } forEach ___exceptions___;
+        exitCode__ - 1;
+    }
+    else
+    {
+        diag_log "";
+        diag_log(["FAILED", "SUCCESS"] select(testsPassed == testsIndex));
+        exitcode__(testsIndex - testsPassed);
+    };
+};


### PR DESCRIPTION
Finally got time to sit down & fix the incomplete CTest implementation I've added earlier. Unfortunately I wasn't able to integrate it directly with `runTests.sqf` - but went for the next best alternative and converted it to a script which executes a specific test file