### PR TITLE
Fixed configClasses returning non-class entities

### DIFF
--- a/src/operators/ops_config.cpp
+++ b/src/operators/ops_config.cpp
@@ -252,7 +252,9 @@ namespace
                 {
                     if (res->is<t_boolean>())
                     {
-                        if (res->data<d_boolean, bool>()) {
+                        auto nav = m_iterator_current.nav();
+                        bool is_class = nav->size() > 0 || (nav->size() == 0 && nav->value.empty());
+                        if (res->data<d_boolean, bool>() && is_class) {
                             m_out_arr->push_back({ *m_iterator_current });
                         }
                     }

--- a/src/runtime/confighost.h
+++ b/src/runtime/confighost.h
@@ -181,6 +181,12 @@ namespace sqf::runtime
                 auto actual_index = container[m_index];
                 return m_confighost.m_containers[actual_index];
             }
+            inline confignav nav()
+            {
+                auto& container = m_confighost.m_containers[m_id];
+                auto actual_index = container[m_index];
+                return confignav(m_confighost, actual_index);
+            }
         };
         using iterator = iterator_base<false>;
         using iterator_recursive = iterator_base<true>;
@@ -414,4 +420,4 @@ namespace sqf::runtime
     };
     inline confignav config::navigate(confighost& host) const { return { host, m_container_id }; }
     inline confignav confighost::root() { return { *this, 0 }; }
-}
+    }

--- a/tests/sqf/config.sqf
+++ b/tests/sqf/config.sqf
@@ -55,5 +55,7 @@
     ["assertEqual",     { ("getNumber (_x >> 'key') == 5" configClasses (configFile >> "flat_tests")) }, [configFile >> "flat_tests" >> "E"]],
     ["assertEqual",     { ("(getNumber (_x >> 'key')) % 2 == 0" configClasses (configFile >> "flat_tests")) }, [configFile >> "flat_tests" >> "B", configFile >> "flat_tests" >> "D"]],
     ["assertEqual",     { configName ((configFile >> "test_select_selects_addon") select 0) }, "addon"],
-    ["assertEqual",     { ("true" configClasses (configFile >> "test_config_classes_only_returns_config_entries")) apply { configName _x } }, ["TestSub"]]
+    ["assertEqual",     { ("true" configClasses (configFile >> "test_config_classes_only_returns_config_entries")) apply { configName _x } }, ["TestSub"]],
+    ["assertEqual",     { ("true" configClasses (configFile >> "nested_tests")) apply { configName _x } }, ["nested1"]],
+    ["assertEqual",     { ("true" configClasses (configFile >> "nested_tests" >> "nested1")) apply { configName _x } }, ["nested2"]]
 ]


### PR DESCRIPTION
This not the full fix (as I the code will likely still be executed on non-class entities), but it covers the most common case of `"true" configClasses (...)`